### PR TITLE
Feature/common config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,10 @@ script:
 - |
   if [ "$TRAVIS_BRANCH" == "master" ]; then
     cross build --release --target x86_64-unknown-linux-musl
+    sh ci/build_apk.sh
   else
     cargo fmt --all -- --write-mode=diff
     cargo build
-  fi
-after_script:
-- |
-  if [ "$TRAVIS_BRANCH" == "master" ]; then
-    sh ci/build_apk.sh
   fi
 deploy:
   provider: releases

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -30,9 +30,9 @@ subcommands:
                 multiple: true
                 takes_value: true
                 help: Command to execute in a forked process.
-    - shell:
-        about: Starts a shell given the value for the key provided (Ex. a postgres config will start a postgres shell).
-        args:
-            - key:
-                required: true
-                help: Command to execute in a forked process.
+                #- shell:
+                #about: Starts a shell given the value for the key provided (Ex. a postgres config will start a postgres shell).
+                #args:
+                #- key:
+                #required: true
+                #help: Command to execute in a forked process.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,8 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 
-use std::{collections::HashSet, fs::File, hash::Hash, io::prelude::*, path::PathBuf, process::Command};
+use std::{collections::HashSet, fs::File, hash::Hash, io::prelude::*, path::PathBuf,
+          process::Command};
 
 use clap::App;
 
@@ -29,8 +30,8 @@ use output::{Exportable, /*Postgres,*/ Printable};
 use types::Result;
 
 fn merge_fields<T>(service_fields: Vec<T>, shared_fields: Vec<T>) -> Vec<T>
-    where
-        T: Hash + Eq
+where
+    T: Hash + Eq,
 {
     let mut ssm: HashSet<_> = service_fields.into_iter().collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 
-use std::{fs::File, io::prelude::*, path::PathBuf, process::Command};
+use std::{collections::HashSet, fs::File, hash::Hash, io::prelude::*, path::PathBuf, process::Command};
 
 use clap::App;
 
@@ -25,27 +25,43 @@ mod types;
 
 use config::Config;
 use error::Error;
-use output::{Exportable, Postgres, Printable};
+use output::{Exportable, /*Postgres,*/ Printable};
 use types::Result;
 
-fn output_describe(config: &Config) -> Result<()> {
-    let ssm = ssm::SsmClient::default();
-    let ssm = ssm.describe_parameters(config)?;
-    let secrets_manager = secretsmanager::SecretsManagerClient::default();
-    let secrets_manager = secrets_manager.list_secrets(config)?;
+fn merge_fields<T>(service_fields: Vec<T>, shared_fields: Vec<T>) -> Vec<T>
+    where
+        T: Hash + Eq
+{
+    let mut ssm: HashSet<_> = service_fields.into_iter().collect();
 
-    // TODO fix this print format
+    for field in shared_fields {
+        ssm.insert(field);
+    }
+
+    ssm.into_iter().collect()
+}
+
+fn output_describe(config: &Config, shared_config: &Config) -> Result<()> {
+    let ssm_client = ssm::SsmClient::default();
+    let service_fields = ssm_client.describe_parameters(config)?;
+    let shared_fields = ssm_client.describe_parameters(shared_config)?;
+    let ssm = merge_fields(service_fields, shared_fields);
+    //let secrets_manager = secretsmanager::SecretsManagerClient::default();
+    //let secrets_manager = secrets_manager.list_secrets(config)?;
+
     ssm.get_table().printstd();
-    secrets_manager.get_table().printstd();
+    //secrets_manager.get_table().printstd();
 
     Ok(())
 }
 
-fn output_stdout(config: &Config) -> Result<()> {
-    let ssm = ssm::SsmClient::default();
-    let ssm = ssm.get_parameters(config)?;
-    let secrets_manager = secretsmanager::SecretsManagerClient::default();
-    let secrets_manager = secrets_manager.get_secret_values(config)?;
+fn output_stdout(config: &Config, shared_config: &Config) -> Result<()> {
+    let ssm_client = ssm::SsmClient::default();
+    let service_fields = ssm_client.get_parameters(config)?;
+    let shared_fields = ssm_client.get_parameters(shared_config)?;
+    let ssm = merge_fields(service_fields, shared_fields);
+    //let secrets_manager = secretsmanager::SecretsManagerClient::default();
+    //let secrets_manager = secrets_manager.get_secret_values(config)?;
 
     let mut closure = move |pairs: Vec<(String, String)>| {
         for (k, v) in pairs {
@@ -54,20 +70,22 @@ fn output_stdout(config: &Config) -> Result<()> {
     };
 
     ssm.export().map(&mut closure);
-    secrets_manager.export().map(&mut closure);
+    //secrets_manager.export().map(&mut closure);
 
     Ok(())
 }
 
-fn output_file<S>(config: &Config, path: S) -> Result<()>
+fn output_file<S>(config: &Config, shared_config: &Config, path: S) -> Result<()>
 where
     S: Into<PathBuf>,
 {
     let path = path.into();
-    let ssm = ssm::SsmClient::default();
-    let ssm = ssm.get_parameters(config)?;
-    let secrets_manager = secretsmanager::SecretsManagerClient::default();
-    let secrets_manager = secrets_manager.get_secret_values(config)?;
+    let ssm_client = ssm::SsmClient::default();
+    let service_fields = ssm_client.get_parameters(config)?;
+    let shared_fields = ssm_client.get_parameters(shared_config)?;
+    let ssm = merge_fields(service_fields, shared_fields);
+    //let secrets_manager = secretsmanager::SecretsManagerClient::default();
+    //let secrets_manager = secrets_manager.get_secret_values(config)?;
 
     path.parent().map(|p| {
         if !p.exists() {
@@ -84,23 +102,25 @@ where
     };
 
     ssm.export().map(&mut closure);
-    secrets_manager.export().map(&mut closure);
+    //secrets_manager.export().map(&mut closure);
 
     Ok(())
 }
 
-fn output_exec(config: &Config, cmd_args: &mut Vec<&str>) -> Result<()> {
+fn output_exec(config: &Config, shared_config: &Config, cmd_args: &mut Vec<&str>) -> Result<()> {
     let cmd = cmd_args.remove(0);
     let mut parameters = Vec::new();
-    let ssm = ssm::SsmClient::default();
-    let ssm = ssm.get_parameters(config)?;
-    let secrets_manager = secretsmanager::SecretsManagerClient::default();
-    let secrets_manager = secrets_manager.get_secret_values(config)?;
+    let ssm_client = ssm::SsmClient::default();
+    let service_fields = ssm_client.get_parameters(config)?;
+    let shared_fields = ssm_client.get_parameters(shared_config)?;
+    let ssm = merge_fields(service_fields, shared_fields);
+    //let secrets_manager = secretsmanager::SecretsManagerClient::default();
+    //let secrets_manager = secrets_manager.get_secret_values(config)?;
 
     ssm.export().map(|mut pairs| parameters.append(&mut pairs));
-    secrets_manager
-        .export()
-        .map(|mut pairs| parameters.append(&mut pairs));
+    //secrets_manager
+    //    .export()
+    //    .map(|mut pairs| parameters.append(&mut pairs));
 
     let mut spawn = Command::new(cmd);
 
@@ -121,23 +141,23 @@ fn output_exec(config: &Config, cmd_args: &mut Vec<&str>) -> Result<()> {
     }
 }
 
-fn output_shell(config: &Config, key: &str) -> Result<()> {
-    let secrets_manager = secretsmanager::SecretsManagerClient::default();
-    let secret = secrets_manager.get_secret_value(config, key)?;
-
-    if let Some(shell_config) = secret.secret_string {
-        let postgres: Postgres = serde_json::from_str(&shell_config)?;
-
-        Command::new("psql")
-            .env_clear()
-            .envs(Into::<Vec<(String, String)>>::into(postgres))
-            .spawn()
-            .map(|_| ())
-            .map_err(Into::into)
-    } else {
-        Err(Error::InvalidKey(format!("{}{}", config.as_path(), key)))
-    }
-}
+//fn output_shell(config: &Config, key: &str) -> Result<()> {
+//    //let secrets_manager = secretsmanager::SecretsManagerClient::default();
+//    //let secret = secrets_manager.get_secret_value(config, key)?;
+//
+//    if let Some(shell_config) = secret.secret_string {
+//        let postgres: Postgres = serde_json::from_str(&shell_config)?;
+//
+//        Command::new("psql")
+//            .env_clear()
+//            .envs(Into::<Vec<(String, String)>>::into(postgres))
+//            .spawn()
+//            .map(|_| ())
+//            .map_err(Into::into)
+//    } else {
+//        Err(Error::InvalidKey(format!("{}{}", config.as_path(), key)))
+//    }
+//}
 
 fn main() {
     openssl_probe::init_ssl_cert_env_vars();
@@ -147,28 +167,31 @@ fn main() {
 
     let environment = matches.value_of("environment").expect("required field");
     let service = matches.value_of("service").expect("required field");
-    let config = Config::new(environment, service);
+    let service_config = Config::new(environment, service);
+    let shared_config = Config::new(environment, "common");
 
     let result = if matches.subcommand_matches("describe").is_some() {
-        output_describe(&config)
+        output_describe(&service_config, &shared_config)
     } else if matches.subcommand_matches("stdout").is_some() {
-        output_stdout(&config)
+        output_stdout(&service_config, &shared_config)
     } else if let Some(file_matches) = matches.subcommand_matches("file") {
         let path = file_matches.value_of("path").expect("required field");
 
-        output_file(&config, path)
+        output_file(&service_config, &shared_config, path)
     } else if let Some(exec_matches) = matches.subcommand_matches("exec") {
         let mut cmd = exec_matches
             .values_of("cmd")
             .expect("required field")
             .collect();
 
-        output_exec(&config, &mut cmd)
-    } else if let Some(shell_matches) = matches.subcommand_matches("shell") {
-        let key = shell_matches.value_of("key").expect("required field");
+        output_exec(&service_config, &shared_config, &mut cmd)
+    }
+    //else if let Some(shell_matches) = matches.subcommand_matches("shell") {
+    //    let key = shell_matches.value_of("key").expect("required field");
 
-        output_shell(&config, key)
-    } else {
+    //    output_shell(&config, key)
+    //}
+    else {
         unreachable!()
     };
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,7 +1,8 @@
 use chrono::NaiveDateTime;
 use prettytable::{format, Table};
 use rusoto_secretsmanager::{GetSecretValueResponse, SecretListEntry};
-use rusoto_ssm::{Parameter, ParameterMetadata};
+
+use ssm::{Parameter, ParameterMetadata};
 
 fn split_take_last(ch: char, field: Option<String>) -> String {
     field

--- a/src/ssm.rs
+++ b/src/ssm.rs
@@ -1,9 +1,85 @@
+use std::hash::{Hash, Hasher};
+
 use rusoto_core::Region;
-use rusoto_ssm::{DescribeParametersRequest, GetParametersByPathRequest, Parameter,
-                 ParameterMetadata, ParameterStringFilter, Ssm, SsmClient as Client};
+use rusoto_ssm::{DescribeParametersRequest, GetParametersByPathRequest, Parameter as RusotoParameter,
+                 ParameterMetadata as RusotoParameterMetadata, ParameterStringFilter, Ssm, SsmClient as Client};
 
 use config::Config;
 use types::Result;
+
+#[derive(Debug)]
+pub struct Parameter{
+    pub name: Option<String>,
+    pub type_: Option<String>,
+    pub value: Option<String>,
+    pub version: Option<i64>,
+}
+
+impl From<RusotoParameter> for Parameter {
+    fn from(rusoto: RusotoParameter) -> Self {
+        Parameter {
+            name: rusoto.name,
+            type_: rusoto.type_,
+            value: rusoto.value,
+            version: rusoto.version,
+        }
+    }
+}
+
+impl PartialEq for Parameter {
+    fn eq(&self, other: &Parameter) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Eq for Parameter {}
+
+impl Hash for Parameter {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state)
+    }
+}
+
+#[derive(Debug)]
+pub struct ParameterMetadata {
+    pub allowed_pattern: Option<String>,
+    pub description: Option<String>,
+    pub key_id: Option<String>,
+    pub last_modified_date: Option<f64>,
+    pub last_modified_user: Option<String>,
+    pub name: Option<String>,
+    pub type_: Option<String>,
+    pub version: Option<i64>,
+}
+
+impl From<RusotoParameterMetadata> for ParameterMetadata {
+    fn from(rusoto: RusotoParameterMetadata) -> Self {
+        ParameterMetadata {
+            allowed_pattern: rusoto.allowed_pattern,
+            description: rusoto.description,
+            key_id: rusoto.key_id,
+            last_modified_date: rusoto.last_modified_date,
+            last_modified_user: rusoto.last_modified_user,
+            name: rusoto.name,
+            type_: rusoto.type_,
+            version: rusoto.version,
+        }
+    }
+}
+
+impl PartialEq for ParameterMetadata {
+    fn eq(&self, other: &ParameterMetadata) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Eq for ParameterMetadata {}
+
+impl Hash for ParameterMetadata {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state)
+    }
+}
 
 pub struct SsmClient {
     inner: Client,
@@ -45,7 +121,7 @@ impl SsmClient {
 
             match res.next_token {
                 Some(next_token) => req.next_token = Some(next_token),
-                _ => return Ok(parameters),
+                _ => return Ok(parameters.into_iter().map(|p| p.into()).collect()),
             }
         }
     }
@@ -70,7 +146,7 @@ impl SsmClient {
 
             match res.next_token {
                 Some(next_token) => req.next_token = Some(next_token),
-                _ => return Ok(parameters),
+                _ => return Ok(parameters.into_iter().map(|p| p.into()).collect()),
             }
         }
     }

--- a/src/ssm.rs
+++ b/src/ssm.rs
@@ -1,14 +1,15 @@
 use std::hash::{Hash, Hasher};
 
 use rusoto_core::Region;
-use rusoto_ssm::{DescribeParametersRequest, GetParametersByPathRequest, Parameter as RusotoParameter,
-                 ParameterMetadata as RusotoParameterMetadata, ParameterStringFilter, Ssm, SsmClient as Client};
+use rusoto_ssm::{DescribeParametersRequest, GetParametersByPathRequest,
+                 Parameter as RusotoParameter, ParameterMetadata as RusotoParameterMetadata,
+                 ParameterStringFilter, Ssm, SsmClient as Client};
 
 use config::Config;
 use types::Result;
 
 #[derive(Debug)]
-pub struct Parameter{
+pub struct Parameter {
     pub name: Option<String>,
     pub type_: Option<String>,
     pub value: Option<String>,


### PR DESCRIPTION
Add a ssm `/{env}/common/` path that gets merged into the service path. The service path fields have preference over the common path fields. This allows the service path fields to overwrite any fields specified by the common path.