### PR TITLE
 Environment from Env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "cloudwrap"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudwrap"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Stephen Cirner <scirner22@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/scirner22/cloudwrap"

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -5,11 +5,13 @@ about: Interfaces with AWS to provide an opinionated way to manage application c
 args:
     - environment:
         required: true
-        index: 1
+        short: e
+        long: environment
+        env: ENVIRONMENT
     - service:
         help: Can be a comma separated list of services. The natural ordering, left to right, is used to resolve key conflicts.
         required: true
-        index: 2
+        index: 1
 subcommands:
     - describe:
         about: Prints configuration keys and extra relevant information, does not include values.

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,5 +1,5 @@
 name: cloudwrap
-version: "0.4.0"
+version: "0.5.0"
 author: Stephen Cirner <scirner22@gmail.com>
 about: Interfaces with AWS to provide an opinionated way to manage application configuration.
 args:
@@ -7,11 +7,13 @@ args:
         required: true
         short: e
         long: environment
-        env: ENVIRONMENT
+        env: CLOUDWRAP_ENVIRONMENT
     - service:
         help: Can be a comma separated list of services. The natural ordering, left to right, is used to resolve key conflicts.
         required: true
-        index: 1
+        short: s
+        long: service
+        env: CLOUDWRAP_SERVICE
 subcommands:
     - describe:
         about: Prints configuration keys and extra relevant information, does not include values.


### PR DESCRIPTION
Change environment parameter to come from the env or from a named parameter, removing the need to run cloudwrap in a shell to get env vars.

Currently have to use `ENTRYPOINT [sh, -c, cloudwrap ${ENVIRONMENT} model exec java -jar app.jar]` to get the environment into cloudwrap. Using `sh -c` makes it difficult to pass in additional args via the CMD functionality at run time. As a work around tried: `ENTRYPOINT [sh, -c, cloudwrap ${ENVIRONMENT} model exec java -jar app.jar @0 $@]` but the additonal args are parsed by java as an entire string. 

This change allows cloudwrap to act as a pure entrypoint script and properly pass all args through to the underlying program negating the need for `sh -c`.